### PR TITLE
RHOL-11: Refactor `CostAccountingAlg`

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -2,31 +2,27 @@ package coop.rchain.casper.util.rholang
 
 import cats.implicits._
 import com.google.protobuf.ByteString
-import coop.rchain.casper.util.ProtoUtil
-import coop.rchain.casper.PrettyPrinter.buildString
 import coop.rchain.casper.protocol._
+import coop.rchain.casper.util.ProtoUtil
+import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
 import coop.rchain.catscontrib.TaskContrib._
-import coop.rchain.crypto.hash.Blake2b512Random
-import coop.rchain.models._
-import coop.rchain.rholang.interpreter.{ErrorLog, Reduce, Runtime}
-import coop.rchain.rholang.interpreter.errors.InterpreterError
-import coop.rchain.rholang.interpreter.storage.StoragePrinter
-import coop.rchain.rspace.{trace, Blake2b256Hash, Checkpoint, ReplayException}
-import monix.execution.Scheduler
-import coop.rchain.rspace.internal.WaitingContinuation
-
-import scala.concurrent.SyncVar
-import scala.util.{Failure, Success, Try}
-import RuntimeManager.StateHash
 import coop.rchain.crypto.codec.Base16
+import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Channel.ChannelInstance.Quote
-import coop.rchain.models.Expr.ExprInstance.{GInt, GString}
+import coop.rchain.models.Expr.ExprInstance.GString
+import coop.rchain.models._
 import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
-import coop.rchain.rspace.internal.Datum
+import coop.rchain.rholang.interpreter.storage.StoragePrinter
+import coop.rchain.rholang.interpreter.{ErrorLog, Reduce, Runtime}
+import coop.rchain.rspace.internal.{Datum, WaitingContinuation}
 import coop.rchain.rspace.trace.Produce
+import coop.rchain.rspace.{Blake2b256Hash, ReplayException}
 import monix.eval.Task
+import monix.execution.Scheduler
 
 import scala.collection.immutable
+import scala.concurrent.SyncVar
+import scala.util.{Failure, Success, Try}
 
 //runtime is a SyncVar for thread-safety, as all checkpoints share the same "hot store"
 class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: SyncVar[Runtime]) {
@@ -204,13 +200,13 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
     Try(reducer.inj(deploy.term.get).unsafeRunSync) match {
       case Success(_) =>
         val errors = errorLog.readAndClearErrorVector()
-        val cost   = CostAccount.toProto(costAlg.getCost().unsafeRunSync)
+        val cost   = CostAccount.toProto(costAlg.get().unsafeRunSync)
         cost -> errors
 
       case Failure(ex) =>
         val otherErrors = errorLog.readAndClearErrorVector()
         val errors      = otherErrors :+ ex
-        val cost        = CostAccount.toProto(costAlg.getCost().unsafeRunSync)
+        val cost        = CostAccount.toProto(costAlg.get().unsafeRunSync)
         cost -> errors
     }
   }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -9,15 +9,9 @@ import coop.rchain.models.Par
 import coop.rchain.models.rholang.implicits.VectorPar
 import coop.rchain.models.rholang.sort.Sortable
 import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
-import coop.rchain.rholang.interpreter.errors.{
-  InterpreterError,
-  SyntaxError,
-  TopLevelFreeVariablesNotAllowedError,
-  TopLevelWildcardsNotAllowedError,
-  UnrecognizedInterpreterError
-}
+import coop.rchain.rholang.interpreter.errors.{InterpreterError, SyntaxError, TopLevelFreeVariablesNotAllowedError, TopLevelWildcardsNotAllowedError, UnrecognizedInterpreterError}
 import coop.rchain.rholang.syntax.rholang_mercury.Absyn.Proc
-import coop.rchain.rholang.syntax.rholang_mercury.{parser, Yylex}
+import coop.rchain.rholang.syntax.rholang_mercury.{Yylex, parser}
 import monix.eval.{Coeval, Task}
 
 private class FailingTask[T](task: Task[Either[Throwable, T]]) {
@@ -99,7 +93,7 @@ object Interpreter {
       costAccounting <- CostAccountingAlg[Task](CostAccount.zero)
       _              <- runtime.reducer.inj(normalizedTerm)(rand, costAccounting)
       errors         <- Task.now(runtime.readAndClearErrorVector())
-      cost           <- costAccounting.getCost()
+      cost           <- costAccounting.get()
       _              <- Task.now(if (errors.nonEmpty) runtime.space.reset(checkpoint.root))
     } yield EvaluateResult(cost, errors)
   }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -389,7 +389,7 @@ object Reduce {
                                                        costAccountingAlg)
                 (cost, matchResult) = SpatialMatcher
                   .spatialMatch(target, pattern)
-                  .runWithCost
+                  .runWithCost(CostAccount(0))
                 _ <- costAccountingAlg.modify(_.charge(cost))
                 res <- matchResult match {
                         case None =>
@@ -653,7 +653,7 @@ object Reduce {
             substPattern <- substituteAndCharge[Par, M](pattern, 1, env, costAccountingAlg)
             (cost, matchResult) = SpatialMatcher
               .spatialMatch(substTarget, substPattern)
-              .runWithCost
+              .runWithCost(CostAccount(0))
 
             _ <- costAccountingAlg.modify(_.charge(cost))
           } yield GBool(matchResult.isDefined)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -108,9 +108,10 @@ object Reduce {
         persistent: Boolean,
         rand: Blake2b512Random)(implicit costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
       for {
-        _ <- costAccountingAlg.charge(Channel(chan).storageCost + data.storageCost)
-        c <- tuplespaceAlg.produce(Channel(chan), ListChannelWithRandom(data, rand), persistent)
-        _ <- costAccountingAlg.modify(_.charge(c))
+        _    <- costAccountingAlg.charge(Channel(chan).storageCost + data.storageCost)
+        c    <- tuplespaceAlg.produce(Channel(chan), ListChannelWithRandom(data, rand), persistent)
+        phlo <- costAccountingAlg.get().map(_ + c)
+        _    <- costAccountingAlg.set(phlo)
       } yield ()
 
     /**
@@ -133,9 +134,10 @@ object Reduce {
       val srcs                                              = sources.map(q => Channel(q)).toList
       val rspaceCost                                        = body.storageCost + patterns.storageCost + srcs.storageCost
       for {
-        _ <- costAccountingAlg.charge(rspaceCost)
-        c <- tuplespaceAlg.consume(binds, ParWithRandom(body, rand), persistent)
-        _ <- costAccountingAlg.modify(_.charge(c))
+        _    <- costAccountingAlg.charge(rspaceCost)
+        c    <- tuplespaceAlg.consume(binds, ParWithRandom(body, rand), persistent)
+        phlo <- costAccountingAlg.get().map(_ + c)
+        _    <- costAccountingAlg.set(phlo)
       } yield ()
     }
 
@@ -219,7 +221,7 @@ object Reduce {
     override def inj(par: Par)(implicit rand: Blake2b512Random,
                                costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
       for {
-        _ <- costAccountingAlg.setCost(CostAccount.zero)
+        _ <- costAccountingAlg.set(CostAccount.zero)
         _ <- eval(par)(Env[Par](), rand, costAccountingAlg)
       } yield ()
 
@@ -387,10 +389,10 @@ object Reduce {
                                                        1,
                                                        env,
                                                        costAccountingAlg)
-                (cost, matchResult) = SpatialMatcher
+                (phlos, matchResult) = SpatialMatcher
                   .spatialMatch(target, pattern)
                   .runWithCost(CostAccount(0))
-                _ <- costAccountingAlg.modify(_.charge(cost))
+                _ <- costAccountingAlg.charge(phlos.cost)
                 res <- matchResult match {
                         case None =>
                           Applicative[M].pure(Left((target, caseRem)))
@@ -651,11 +653,11 @@ object Reduce {
             evaledTarget <- evalExpr(target)
             substTarget  <- substituteAndCharge[Par, M](evaledTarget, 0, env, costAccountingAlg)
             substPattern <- substituteAndCharge[Par, M](pattern, 1, env, costAccountingAlg)
-            (cost, matchResult) = SpatialMatcher
+            (phlos, matchResult) = SpatialMatcher
               .spatialMatch(substTarget, substPattern)
               .runWithCost(CostAccount(0))
 
-            _ <- costAccountingAlg.modify(_.charge(cost))
+            _ <- costAccountingAlg.charge(phlos.cost)
           } yield GBool(matchResult.isDefined)
 
         case EPercentPercentBody(EPercentPercent(p1, p2)) =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingAlg.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingAlg.scala
@@ -1,44 +1,39 @@
 package coop.rchain.rholang.interpreter.accounting
 
-import cats.Monad
 import cats.effect.Sync
 import cats.effect.concurrent.Ref
-import coop.rchain.rholang.interpreter.accounting
 import cats.implicits._
+import cats.{FlatMap, Monad}
+import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 
 trait CostAccountingAlg[F[_]] {
   def charge(cost: Cost): F[Unit]
-  def modify(f: CostAccount => CostAccount): F[Unit]
-  def getCost(): F[CostAccount]
-  def setCost(cost: CostAccount): F[Unit]
+  def get(): F[CostAccount]
+  def set(cost: CostAccount): F[Unit]
 }
 
 object CostAccountingAlg {
-  def apply[F[_]: Sync](init: CostAccount): F[CostAccountingAlg[F]] = Ref[F].of(init).map { state =>
-    new CostAccountingAlg[F] {
-      override def charge(cost: Cost): F[Unit]                    = state.update(_.charge(cost))
-      override def modify(f: CostAccount => CostAccount): F[Unit] = state.update(f)
-      override def getCost: F[CostAccount]                        = state.get
-      override def setCost(cost: CostAccount): F[Unit]            = state.set(cost)
-    }
-  }
+  def apply[F[_]: Sync](init: CostAccount): F[CostAccountingAlg[F]] =
+    Ref[F].of(init).map(ref => new CostAccountingAlgImpl[F](ref))
 
   def of[F[_]](implicit ev: CostAccountingAlg[F]): CostAccountingAlg[F] = ev
 
-  def unsafe[F[_]: Monad](initialState: CostAccount)(implicit F: Sync[F]): CostAccountingAlg[F] = {
-    val state = Ref.unsafe[F, CostAccount](initialState)
-    new CostAccountingAlg[F] {
+  def unsafe[F[_]: Monad](init: CostAccount)(implicit F: Sync[F]): CostAccountingAlg[F] = {
+    val ref = Ref.unsafe[F, CostAccount](init)
+    new CostAccountingAlgImpl[F](ref)
+  }
 
-      override def modify(f: CostAccount => CostAccount): F[Unit] =
-        F.suspend(state.update(f))
-
-      override def setCost(cost: CostAccount): F[Unit] =
-        F.suspend(state.set(cost))
-
-      override def charge(cost: accounting.Cost): F[Unit] =
-        F.suspend(state.update(_ + cost))
-
-      override def getCost(): F[CostAccount] = F.suspend(state.get)
-    }
+  private class CostAccountingAlgImpl[F[_]](state: Ref[F, CostAccount])(implicit F: Sync[F])
+      extends CostAccountingAlg[F] {
+    override def charge(cost: Cost): F[Unit] =
+      for {
+        _ <- failOnOutOfPhlo
+        _ <- state.update(_.charge(cost))
+        _ <- failOnOutOfPhlo
+      } yield ()
+    override def get: F[CostAccount]             = state.get
+    override def set(cost: CostAccount): F[Unit] = state.set(cost)
+    private val failOnOutOfPhlo: F[Unit] =
+      FlatMap[F].ifM(state.get.map(_.cost.value < 0))(F.raiseError(OutOfPhlogistonsError), F.unit)
   }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -70,7 +70,7 @@ object RholangOnlyDispatcher {
       parallel: Parallel[M, F],
       s: Sync[M],
       ft: FunctorTell[M, Throwable]): Dispatch[M, ListChannelWithRandom, TaggedContinuation] = {
-    val pureSpace = PureRSpace[M].of(tuplespace)
+    val pureSpace          = PureRSpace[M].of(tuplespace)
     lazy val tuplespaceAlg = TuplespaceAlg.rspaceTuplespace(pureSpace, dispatcher)
     lazy val dispatcher: Dispatch[M, ListChannelWithRandom, TaggedContinuation] =
       new RholangOnlyDispatcher(reducer)
@@ -125,7 +125,7 @@ object RholangAndScalaDispatcher {
       parallel: Parallel[M, F],
       s: Sync[M],
       ft: FunctorTell[M, Throwable]): Dispatch[M, ListChannelWithRandom, TaggedContinuation] = {
-    val pureSpace = PureRSpace[M].of(tuplespace)
+    val pureSpace          = PureRSpace[M].of(tuplespace)
     lazy val tuplespaceAlg = TuplespaceAlg.rspaceTuplespace(pureSpace, dispatcher)
     lazy val dispatcher: Dispatch[M, ListChannelWithRandom, TaggedContinuation] =
       new RholangAndScalaDispatcher(reducer, dispatchTable)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -39,8 +39,8 @@ package object matcher {
           }))
         })
 
-      def runWithCost: (CostAccount, Option[(FreeMap, A)]) =
-        s.run(Map.empty).value.run(CostAccount.zero).value
+      def runWithCost(availablePhlos: CostAccount): (CostAccount, Option[(FreeMap, A)]) =
+        s.run(Map.empty).value.run(availablePhlos).value
 
       def toNonDet(): NonDetFreeMapWithCost[A] =
         s.mapK[StreamWithCost](new FunctionK[OptionWithCost, StreamWithCost] {
@@ -96,8 +96,8 @@ package object matcher {
           }))
         })
 
-      def runWithCost: (CostAccount, Stream[(FreeMap, A)]) =
-        s.run(Map.empty).value.run(CostAccount.zero).value
+      def runWithCost(availablePhlos: CostAccount): (CostAccount, Stream[(FreeMap, A)]) =
+        s.run(Map.empty).value.run(availablePhlos).value
 
       def toDet(): OptionalFreeMapWithCost[A] =
         s.mapK[OptionWithCost](new FunctionK[StreamWithCost, OptionWithCost] {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
@@ -39,7 +39,7 @@ object implicits {
         : Either[OutOfPhlogistonsError.type, Option[ListChannelWithRandom]] = {
         val (cost, resultMatch) = SpatialMatcher
           .foldMatch(data.channels, pattern.patterns, pattern.remainder)
-          .runWithCost
+          .runWithCost(CostAccount.zero)
 
         val result = resultMatch
           .map {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -31,11 +31,11 @@ import scala.concurrent.duration._
 trait PersistentStoreTester {
   def withTestSpace[R](
       f: FreudianSpace[Channel,
-                BindPattern,
-                OutOfPhlogistonsError.type,
-                ListChannelWithRandom,
-                ListChannelWithRandom,
-                TaggedContinuation] => R): R = {
+                       BindPattern,
+                       OutOfPhlogistonsError.type,
+                       ListChannelWithRandom,
+                       ListChannelWithRandom,
+                       TaggedContinuation] => R): R = {
     val dbDir               = Files.createTempDirectory("rholang-interpreter-test-")
     val context: RhoContext = Context.create(dbDir, mapSize = 1024L * 1024L * 1024L)
     val space = RSpace.create[Channel,
@@ -931,9 +931,9 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     implicit val errorLog = new ErrorLog()
     implicit val costAccounting =
       CostAccountingAlg.unsafe[Task](CostAccount.zero)
-    val splitRand = rand.splitByte(42)
-    val resultRand = rand.splitByte(42)
-    val chosenName = resultRand.next
+    val splitRand   = rand.splitByte(42)
+    val resultRand  = rand.splitByte(42)
+    val chosenName  = resultRand.next
     val result0Rand = resultRand.splitByte(0)
     val result1Rand = resultRand.splitByte(1)
     val newProc: New =
@@ -943,12 +943,17 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         p = Par(
           sends = List(
             Send(Quote(GString("result0")), List(EVar(BoundVar(0))), locallyFree = BitSet(0)),
-            Send(Quote(GString("result1")), List(EVar(BoundVar(1))), locallyFree = BitSet(1))),
-          locallyFree = BitSet(0, 1)))
+            Send(Quote(GString("result1")), List(EVar(BoundVar(1))), locallyFree = BitSet(1))
+          ),
+          locallyFree = BitSet(0, 1)
+        )
+      )
 
     val result = withTestSpace { space =>
       def byteName(b: Byte): Par = GPrivate(ByteString.copyFrom(Array[Byte](b)))
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space, Map("rho:test:foo" -> byteName(42))).reducer
+      val reducer = RholangOnlyDispatcher
+        .create[Task, Task.Par](space, Map("rho:test:foo" -> byteName(42)))
+        .reducer
       implicit val env = Env[Par]()
       val nthTask      = reducer.eval(newProc)(env, splitRand, costAccounting)
       val inspectTask = for {
@@ -959,6 +964,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
     val channel0 = Channel(Quote(GString("result0")))
     val channel1 = Channel(Quote(GString("result1")))
+    // format: off
     result should be(
       HashMap(
         List(channel0) ->
@@ -980,7 +986,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       )
     )
   }
-
+  // format: on
   "eval of nth method in send position" should "change what is sent" in {
     implicit val errorLog = new ErrorLog()
     implicit val costAccounting =
@@ -1520,10 +1526,11 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           EPercentPercent(
             GString("${a} ${b}"),
             EMapBody(
-              ParMap(List[(Par, Par)](
-                                (GString("a"), GString("1 ${b}")),
-                                (GString("b"), GString("2 ${a}"))
-                              ))
+              ParMap(
+                List[(Par, Par)](
+                  (GString("a"), GString("1 ${b}")),
+                  (GString("b"), GString("2 ${a}"))
+                ))
             )
           )
         )
@@ -1609,8 +1616,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
 
-      val map = EMapBody(
-        ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
+      val map = EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
       val inspectTask = reducer.evalExpr(
         EMethodBody(EMethod("getOrElse", map, List(GInt(1), GString("c"))))
       )
@@ -1630,8 +1636,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
 
-      val map = EMapBody(
-        ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
+      val map = EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
       val inspectTask = reducer.evalExpr(
         EMethodBody(EMethod("getOrElse", map, List(GInt(3), GString("c"))))
       )
@@ -1651,16 +1656,15 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
 
-      val map = EMapBody(
-        ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
+      val map = EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
       val inspectTask = reducer.evalExpr(
         EMethodBody(EMethod("set", map, List(GInt(3), GString("c"))))
       )
 
       Await.result(inspectTask.runAsync, 3.seconds)
     }
-    val resultMap = EMapBody(
-      ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")), (GInt(3), GString("c")))))
+    val resultMap = EMapBody(ParMap(
+      List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")), (GInt(3), GString("c")))))
     result.exprs should be(Seq(Expr(resultMap)))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }
@@ -1674,16 +1678,15 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
 
-      val map = EMapBody(
-        ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
+      val map = EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
       val inspectTask = reducer.evalExpr(
         EMethodBody(EMethod("set", map, List(GInt(2), GString("c"))))
       )
 
       Await.result(inspectTask.runAsync, 3.seconds)
     }
-    val resultMap = EMapBody(
-      ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("c")))))
+    val resultMap =
+      EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("c")))))
     result.exprs should be(Seq(Expr(resultMap)))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }
@@ -1698,9 +1701,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
 
       val map = EMapBody(
-        ParMap(List[(Par, Par)]((GInt(1), GString("a")),
-                                   (GInt(2), GString("b")),
-                                   (GInt(3), GString("c")))))
+        ParMap(
+          List[(Par, Par)]((GInt(1), GString("a")),
+                           (GInt(2), GString("b")),
+                           (GInt(3), GString("c")))))
       val inspectTask = reducer.evalExpr(
         EMethodBody(EMethod("keys", map))
       )
@@ -1725,9 +1729,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
 
       val map = EMapBody(
-        ParMap(List[(Par, Par)]((GInt(1), GString("a")),
-                                   (GInt(2), GString("b")),
-                                   (GInt(3), GString("c")))))
+        ParMap(
+          List[(Par, Par)]((GInt(1), GString("a")),
+                           (GInt(2), GString("b")),
+                           (GInt(3), GString("c")))))
       val inspectTask = reducer.evalExpr(
         EMethodBody(EMethod("size", map))
       )
@@ -1789,17 +1794,18 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
 
       val map = EMapBody(
-        ParMap(List[(Par, Par)]((GInt(1), GString("a")),
-                                   (GInt(2), GString("b")),
-                                   (GInt(3), GString("c")))))
+        ParMap(
+          List[(Par, Par)]((GInt(1), GString("a")),
+                           (GInt(2), GString("b")),
+                           (GInt(3), GString("c")))))
       val inspectTask = reducer.evalExpr(
         EMinusBody(EMinus(map, GInt(3)))
       )
 
       Await.result(inspectTask.runAsync, 3.seconds)
     }
-    val resultMap = EMapBody(
-      ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
+    val resultMap =
+      EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
     result.exprs should be(Seq(Expr(resultMap)))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }
@@ -1856,10 +1862,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
 
-      val lhsMap = EMapBody(
-        ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
-      val rhsMap = EMapBody(
-        ParMap(List[(Par, Par)]((GInt(3), GString("c")), (GInt(4), GString("d")))))
+      val lhsMap =
+        EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
+      val rhsMap =
+        EMapBody(ParMap(List[(Par, Par)]((GInt(3), GString("c")), (GInt(4), GString("d")))))
       val inspectTask = reducer.evalExpr(
         EPlusPlusBody(EPlusPlus(lhsMap, rhsMap))
       )
@@ -1867,12 +1873,13 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       Await.result(inspectTask.runAsync, 3.seconds)
     }
     val resultMap = EMapBody(
-      ParMap(List[(Par, Par)](
-                (GInt(1), GString("a")),
-                (GInt(2), GString("b")),
-                (GInt(3), GString("c")),
-                (GInt(4), GString("d"))
-              )))
+      ParMap(
+        List[(Par, Par)](
+          (GInt(1), GString("a")),
+          (GInt(2), GString("b")),
+          (GInt(3), GString("c")),
+          (GInt(4), GString("d"))
+        )))
     result.exprs should be(Seq(Expr(resultMap)))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }
@@ -1927,8 +1934,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
 
-      val map = EMapBody(
-        ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
+      val map         = EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
       val inspectTask = reducer.eval(EMethodBody(EMethod("add", map, List(GInt(1)))))
 
       Await.result(inspectTask.runAsync, 3.seconds)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -10,8 +10,8 @@ import coop.rchain.models.Connective.ConnectiveInstance._
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.TaggedContinuation.TaggedCont.ParBody
 import coop.rchain.models.Var.VarInstance._
-import coop.rchain.models.rholang.implicits._
 import coop.rchain.models._
+import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.Runtime.RhoContext
 import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
 import coop.rchain.rholang.interpreter.errors._
@@ -407,7 +407,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     //reset the cost
-    Await.ready(costAccounting.setCost(CostAccount.zero).runAsync, 1.second)
+    Await.ready(costAccounting.set(CostAccount.zero).runAsync, 1.second)
 
     val receiveFirstResult = withTestSpace { space =>
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
@@ -479,7 +479,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     //reset the cost
-    Await.ready(costAccounting.setCost(CostAccount.zero).runAsync, 1.second)
+    Await.ready(costAccounting.set(CostAccount.zero).runAsync, 1.second)
 
     val receiveFirstResult = withTestSpace { space =>
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
@@ -549,7 +549,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     //reset the cost
-    Await.ready(costAccounting.setCost(CostAccount.zero).runAsync, 1.second)
+    Await.ready(costAccounting.set(CostAccount.zero).runAsync, 1.second)
 
     val receiveFirstResult = withTestSpace { space =>
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
@@ -630,7 +630,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     //reset the cost
-    Await.ready(costAccounting.setCost(CostAccount.zero).runAsync, 1.second)
+    Await.ready(costAccounting.set(CostAccount.zero).runAsync, 1.second)
 
     val receiveFirstResult = withTestSpace { space =>
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
@@ -656,7 +656,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
-    Await.result(costAccounting.setCost(CostAccount.zero).runAsync, 1.second)
+    Await.result(costAccounting.set(CostAccount.zero).runAsync, 1.second)
 
     val bothResult = withTestSpace { space =>
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
@@ -788,7 +788,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     //reset the cost
-    Await.ready(costAccounting.setCost(CostAccount.zero).runAsync, 1.second)
+    Await.ready(costAccounting.set(CostAccount.zero).runAsync, 1.second)
 
     val receiveFirstResult = withTestSpace { space =>
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
@@ -813,7 +813,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     //reset the cost
-    Await.ready(costAccounting.setCost(CostAccount.zero).runAsync, 1.second)
+    Await.ready(costAccounting.set(CostAccount.zero).runAsync, 1.second)
 
     val interleavedResult = withTestSpace { space =>
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -26,25 +26,24 @@ trait RegistryTester extends PersistentStoreTester {
   implicit val costAccounting =
     CostAccountingAlg.unsafe[Task](CostAccount.zero)
   def withRegistryAndTestSpace[R](
-      f: (Reduce[Task], 
-          FreudianSpace[
-                 Channel,
-                 BindPattern,
-                 OutOfPhlogistonsError.type,
-                 ListChannelWithRandom,
-                 ListChannelWithRandom,
-                 TaggedContinuation]) => R
-          ): R = {
+      f: (Reduce[Task],
+          FreudianSpace[Channel,
+                        BindPattern,
+                        OutOfPhlogistonsError.type,
+                        ListChannelWithRandom,
+                        ListChannelWithRandom,
+                        TaggedContinuation]) => R
+  ): R =
     withTestSpace { space =>
       val pureSpace: Runtime.RhoPureSpace = new PureRSpace(space)
-      lazy val registry: Registry = new Registry(pureSpace, dispatcher)
+      lazy val registry: Registry         = new Registry(pureSpace, dispatcher)
       lazy val dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation] =
-        RholangAndScalaDispatcher.create[Task, Task.Par](space, registry.testingDispatchTable, Registry.testingUrnMap)
+        RholangAndScalaDispatcher
+          .create[Task, Task.Par](space, registry.testingDispatchTable, Registry.testingUrnMap)
       val reducer = dispatcher.reducer
       registry.testInstall()
       f(reducer, space)
     }
-  }
 }
 
 class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
@@ -53,12 +52,13 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     089775e6bbe6f893b810e66615867bede6e16fcf22a5dd869bb17ca8415f0b8e
     0897ef763354e4266d31c74b7a5be55fbfeb464fe65ce56ce9ccbfd9a1fddef0
     0897a37e047d2fc591185812e4a9526ded5509544e6586092c25a17abf366ea3
-  */
+   */
   val eightByteArray: Par       = GByteArray(ByteString.copyFrom(Array[Byte](0x08.toByte)))
   val ninetySevenByteArray: Par = GByteArray(ByteString.copyFrom(Array[Byte](0x97.toByte)))
   val branchName: Par = GPrivate(
     ByteString.copyFrom(
       Base16.decode("d5fd3d8daf9f295aa590b37b50d5518803b4596ed6940aa42d46b1413a1bb16e")))
+  // format: off
   val rootSend: Send = Send(
     chan = Quote(Registry.registryRoot),
     data = Seq(
@@ -66,22 +66,34 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
         ParMap(Seq(eightByteArray -> Par(exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(1), ninetySevenByteArray, branchName))))))))))),
     persistent = false
   )
-  val sevenFiveByteArray: Par   = GByteArray(ByteString.copyFrom(Array[Byte](0x75.toByte)))
-  val aThreeByteArray: Par   = GByteArray(ByteString.copyFrom(Array[Byte](0xa3.toByte)))
-  val eNineByteArray: Par  = GByteArray(ByteString.copyFrom(Array[Byte](0xe9.toByte)))
-  val efByteArray: Par  = GByteArray(ByteString.copyFrom(Array[Byte](0xef.toByte)))
-  val emptyByteArray: Par  = GByteArray(ByteString.EMPTY)
-  val branch1: Par         = GByteArray(ByteString.copyFrom(Base16.decode("533fd9c5c26e7ea3fe07f99a4dbbde31eb2c59f84810d03e078e7d31c2")))
-  val branch2: Par         = GByteArray(ByteString.copyFrom(Base16.decode("e6bbe6f893b810e66615867bede6e16fcf22a5dd869bb17ca8415f0b8e")))
-  val branch3: Par         = GByteArray(ByteString.copyFrom(Base16.decode("763354e4266d31c74b7a5be55fbfeb464fe65ce56ce9ccbfd9a1fddef0")))
-  val branch4: Par         = GByteArray(ByteString.copyFrom(Base16.decode("7e047d2fc591185812e4a9526ded5509544e6586092c25a17abf366ea3")))
+  // format: on
+  val sevenFiveByteArray: Par = GByteArray(ByteString.copyFrom(Array[Byte](0x75.toByte)))
+  val aThreeByteArray: Par    = GByteArray(ByteString.copyFrom(Array[Byte](0xa3.toByte)))
+  val eNineByteArray: Par     = GByteArray(ByteString.copyFrom(Array[Byte](0xe9.toByte)))
+  val efByteArray: Par        = GByteArray(ByteString.copyFrom(Array[Byte](0xef.toByte)))
+  val emptyByteArray: Par     = GByteArray(ByteString.EMPTY)
+  val branch1: Par = GByteArray(
+    ByteString.copyFrom(
+      Base16.decode("533fd9c5c26e7ea3fe07f99a4dbbde31eb2c59f84810d03e078e7d31c2")))
+  val branch2: Par = GByteArray(
+    ByteString.copyFrom(
+      Base16.decode("e6bbe6f893b810e66615867bede6e16fcf22a5dd869bb17ca8415f0b8e")))
+  val branch3: Par = GByteArray(
+    ByteString.copyFrom(
+      Base16.decode("763354e4266d31c74b7a5be55fbfeb464fe65ce56ce9ccbfd9a1fddef0")))
+  val branch4: Par = GByteArray(
+    ByteString.copyFrom(
+      Base16.decode("7e047d2fc591185812e4a9526ded5509544e6586092c25a17abf366ea3")))
   val branchSend: Send = Send(
     chan = Quote(branchName),
     data = Seq(
       Expr(EMapBody(ParMap(Seq(
-        emptyByteArray  -> Par(exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), emptyByteArray, GInt(7))))))),
-        eNineByteArray     -> Par(exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch1, GInt(8))))))),
-        sevenFiveByteArray -> Par(exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch2, GInt(9)))))))
+        emptyByteArray -> Par(
+          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), emptyByteArray, GInt(7))))))),
+        eNineByteArray -> Par(
+          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch1, GInt(8))))))),
+        sevenFiveByteArray -> Par(
+          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch2, GInt(9)))))))
       ))))),
     persistent = false
   )
@@ -90,17 +102,21 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     chan = Quote(branchName),
     data = Seq(
       Expr(EMapBody(ParMap(Seq(
-        eNineByteArray     -> Par(exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch1, GInt(8))))))),
-        sevenFiveByteArray -> Par(exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch2, GInt(9))))))),
-        efByteArray   -> Par(exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch3, GInt(10))))))),
-        aThreeByteArray  -> Par(exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch4, GInt(11)))))))
+        eNineByteArray -> Par(
+          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch1, GInt(8))))))),
+        sevenFiveByteArray -> Par(
+          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch2, GInt(9))))))),
+        efByteArray -> Par(exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch3, GInt(10))))))),
+        aThreeByteArray -> Par(
+          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch4, GInt(11)))))))
       ))))),
     persistent = false
   )
 
   val baseRand: Blake2b512Random = Blake2b512Random(Array.empty[Byte])
   "lookup" should "recurse" in {
-    val lookupString: String = """
+    val lookupString: String =
+      """
       new r(`rho:registry:testing:lookup`) in {
         r!("0897".hexToBytes(), "result0") |
         r!("089775e6bbe6f893b810e66615867bede6e16fcf22a5dd869bb17ca8415f0b8e".hexToBytes(), "result1") |
@@ -111,7 +127,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
 
     val completePar                     = lookupPar.addSends(rootSend, branchSend)
     implicit val rand: Blake2b512Random = baseRand.splitByte(1)
-    val newRand = rand.splitByte(2)
+    val newRand                         = rand.splitByte(2)
     val randResult0                     = newRand.splitByte(0)
     randResult0.next; randResult0.next
     val randResult1 = newRand.splitByte(1)
@@ -120,7 +136,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     randResult2.next; randResult2.next
 
     val result = withRegistryAndTestSpace { (reducer, space) =>
-      implicit val env    = Env[Par]()
+      implicit val env = Env[Par]()
       val resultTask = for {
         _ <- reducer.eval(completePar)
       } yield space.store.toMap
@@ -131,33 +147,34 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
       List(Channel(Quote(GString(s))))
 
     result.get(resultChanList("result0")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result0"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(7))), randResult0),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result0"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(7))), randResult0),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result1")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result1"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(9))), randResult1),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result1"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(9))), randResult1),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result2")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result2"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(8))), randResult2),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result2"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(8))), randResult2),
+                            false)),
+          List()
+        )))
   }
 
   "insert" should "successfully split" in {
-    val insertString = """
+    val insertString =
+      """
         new rl(`rho:registry:testing:lookup`), ri(`rho:registry:testing:insert`), ack in {
           ri!("0897e953".hexToBytes(), 10, *ack) |
           for (@10 <- ack) { //merge 0
@@ -195,8 +212,8 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
             }
           }
         }"""
-    val insertPar: Par = Interpreter.buildNormalizedTerm(new StringReader(insertString)).value
-    val completePar                     = insertPar.addSends(rootSend, branchSend)
+    val insertPar: Par                      = Interpreter.buildNormalizedTerm(new StringReader(insertString)).value
+    val completePar                         = insertPar.addSends(rootSend, branchSend)
     implicit val evalRand: Blake2b512Random = baseRand.splitByte(2)
 
     // Compute the random states for the results
@@ -208,38 +225,38 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     val insert0Rand = newRand.splitByte(0)
     // Twice for lookup, once for new name to insert.
     insert0Rand.next(); insert0Rand.next(); insert0Rand.next()
-    val merge0 = Blake2b512Random.merge(Seq(newRand.splitByte(1), insert0Rand.splitByte(1)))
+    val merge0      = Blake2b512Random.merge(Seq(newRand.splitByte(1), insert0Rand.splitByte(1)))
     val lookup0Rand = merge0.splitByte(0)
     // It takes 3 now because of the previous insert.
     lookup0Rand.next(); lookup0Rand.next(); lookup0Rand.next()
-    val merge1 = Blake2b512Random.merge(Seq(merge0.splitByte(1), lookup0Rand))
+    val merge1      = Blake2b512Random.merge(Seq(merge0.splitByte(1), lookup0Rand))
     val result0Rand = merge1.splitByte(0)
     val lookup1Rand = merge1.splitByte(1)
     lookup1Rand.next(); lookup1Rand.next(); lookup1Rand.next()
-    val merge2 = Blake2b512Random.merge(Seq(merge1.splitByte(2), lookup1Rand))
+    val merge2      = Blake2b512Random.merge(Seq(merge1.splitByte(2), lookup1Rand))
     val result1Rand = merge2.splitByte(0)
     val insert1Rand = merge2.splitByte(1)
     //0897e9 only takes 2 lookups (root, and 0897). It uses 1 more to split
     insert1Rand.next(); insert1Rand.next(); insert1Rand.next()
-    val merge3 = Blake2b512Random.merge(Seq(merge2.splitByte(2), insert1Rand.splitByte(1)))
+    val merge3      = Blake2b512Random.merge(Seq(merge2.splitByte(2), insert1Rand.splitByte(1)))
     val lookup2Rand = merge3.splitByte(0)
     // It takes 4 lookups now because of the second insert.
     lookup2Rand.next(); lookup2Rand.next(); lookup2Rand.next(); lookup2Rand.next()
-    val merge4 = Blake2b512Random.merge(Seq(merge3.splitByte(1), lookup2Rand))
+    val merge4      = Blake2b512Random.merge(Seq(merge3.splitByte(1), lookup2Rand))
     val result2Rand = merge4.splitByte(0)
     val lookup3Rand = merge4.splitByte(1)
     lookup3Rand.next(); lookup3Rand.next(); lookup3Rand.next(); lookup3Rand.next()
-    val merge5 = Blake2b512Random.merge(Seq(merge4.splitByte(2), lookup3Rand))
+    val merge5      = Blake2b512Random.merge(Seq(merge4.splitByte(2), lookup3Rand))
     val result3Rand = merge5.splitByte(0)
     val lookup4Rand = merge5.splitByte(1)
     //Only 3 lookups: root, 0897, e9
     lookup4Rand.next(); lookup4Rand.next(); lookup4Rand.next()
-    val merge6 = Blake2b512Random.merge(Seq(merge5.splitByte(2), lookup4Rand))
+    val merge6      = Blake2b512Random.merge(Seq(merge5.splitByte(2), lookup4Rand))
     val result4Rand = merge6.splitByte(0)
     val insert2Rand = merge6.splitByte(1)
     // Only 2 because we perform a split at the root
     insert2Rand.next(); insert2Rand.next()
-    val merge7 = Blake2b512Random.merge(Seq(merge6.splitByte(2), insert2Rand.splitByte(1)))
+    val merge7      = Blake2b512Random.merge(Seq(merge6.splitByte(2), insert2Rand.splitByte(1)))
     val result5Rand = merge7.splitByte(0)
     result5Rand.next(); result5Rand.next(); result5Rand.next()
     val result6Rand = merge7.splitByte(1)
@@ -247,14 +264,16 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     val result7Rand = merge7.splitByte(2)
     result7Rand.next(); result7Rand.next(); result7Rand.next(); result7Rand.next()
     val result8Rand = merge7.splitByte(3)
-    result8Rand.next(); result8Rand.next(); result8Rand.next(); result8Rand.next(); result8Rand.next()
+    result8Rand.next(); result8Rand.next(); result8Rand.next(); result8Rand.next();
+    result8Rand.next()
     val result9Rand = merge7.splitByte(4)
-    result9Rand.next(); result9Rand.next(); result9Rand.next(); result9Rand.next(); result9Rand.next()
+    result9Rand.next(); result9Rand.next(); result9Rand.next(); result9Rand.next();
+    result9Rand.next()
     val result10Rand = merge7.splitByte(5)
     result10Rand.next(); result10Rand.next()
 
     val result = withRegistryAndTestSpace { (reducer, space) =>
-      implicit val env    = Env[Par]()
+      implicit val env = Env[Par]()
       val resultTask = for {
         _ <- reducer.eval(completePar)
       } yield space.store.toMap
@@ -265,99 +284,100 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
       List(Channel(Quote(GString(s))))
 
     result.get(resultChanList("result0")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result0"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(8))), result0Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result0"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(8))), result0Rand),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result1")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result1"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(10))), result1Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result1"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(10))), result1Rand),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result2")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result2"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(8))), result2Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result2"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(8))), result2Rand),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result3")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result3"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(10))), result3Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result3"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(10))), result3Rand),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result4")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result4"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(11))), result4Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result4"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(11))), result4Rand),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result5")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result5"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(7))), result5Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result5"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(7))), result5Rand),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result6")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result6"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(9))), result6Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result6"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(9))), result6Rand),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result7")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result7"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(11))), result7Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result7"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(11))), result7Rand),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result8")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result8"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(10))), result8Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result8"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(10))), result8Rand),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result9")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result9"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(8))), result9Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result9"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(8))), result9Rand),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result10")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result10"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(12))), result10Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result10"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(12))), result10Rand),
+                            false)),
+          List()
+        )))
   }
 
   "delete" should "successfully merge" in {
     /* The overview of this program is 1 delete, 3 lookups, 1 delete,
     2 lookups, 1 delete, 1 lookup, 1 delete */
-    val deleteString = """
+    val deleteString =
+      """
       new rl(`rho:registry:testing:lookup`), rd(`rho:registry:testing:delete`), ack in {
         rd!("0897a37e047d2fc591185812e4a9526ded5509544e6586092c25a17abf366ea3".hexToBytes(), *ack) |
         for (@11 <- ack) { //merge 0
@@ -394,12 +414,12 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
           }
         }
       }"""
-    val deletePar: Par = Interpreter.buildNormalizedTerm(new StringReader(deleteString)).value
+    val deletePar: Par                  = Interpreter.buildNormalizedTerm(new StringReader(deleteString)).value
     val completePar                     = deletePar.addSends(rootSend, fullBranchSend)
     implicit val rand: Blake2b512Random = baseRand.splitByte(3)
 
     val result = withRegistryAndTestSpace { (reducer, space) =>
-      implicit val env    = Env[Par]()
+      implicit val env = Env[Par]()
       val resultTask = for {
         _ <- reducer.eval(completePar)
       } yield space.store.toMap
@@ -409,47 +429,47 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     // Compute the random states for the results
     val resultRand = baseRand.splitByte(3)
     // The two sends setting up the initial state, and then the new.
-    val newRand = resultRand.splitByte(2)
+    val newRand  = resultRand.splitByte(2)
     val rootRand = resultRand.splitByte(0)
     // once, for ack.
     newRand.next()
     val delete0Rand = newRand.splitByte(0)
     // Once for root, and twice for a single iteration through the tree
     delete0Rand.next(); delete0Rand.next(); delete0Rand.next()
-    val merge0 = Blake2b512Random.merge(Seq(newRand.splitByte(1), delete0Rand))
+    val merge0      = Blake2b512Random.merge(Seq(newRand.splitByte(1), delete0Rand))
     val lookup0Rand = merge0.splitByte(0)
     lookup0Rand.next(); lookup0Rand.next();
-    val merge1 = Blake2b512Random.merge(Seq(merge0.splitByte(1), lookup0Rand))
+    val merge1      = Blake2b512Random.merge(Seq(merge0.splitByte(1), lookup0Rand))
     val result0Rand = merge1.splitByte(0)
     val lookup1Rand = merge1.splitByte(1)
     lookup1Rand.next(); lookup1Rand.next();
-    val merge2 = Blake2b512Random.merge(Seq(merge1.splitByte(2), lookup1Rand))
+    val merge2      = Blake2b512Random.merge(Seq(merge1.splitByte(2), lookup1Rand))
     val result1Rand = merge2.splitByte(0)
     val lookup2Rand = merge2.splitByte(1)
     lookup2Rand.next(); lookup2Rand.next();
-    val merge3 = Blake2b512Random.merge(Seq(merge2.splitByte(2), lookup2Rand))
+    val merge3      = Blake2b512Random.merge(Seq(merge2.splitByte(2), lookup2Rand))
     val result2Rand = merge3.splitByte(0)
     val delete1Rand = merge3.splitByte(1)
     // Once for root, and twice for a single iteration through the tree
     delete1Rand.next(); delete1Rand.next(); delete1Rand.next()
-    val merge4 = Blake2b512Random.merge(Seq(merge3.splitByte(2), delete1Rand))
+    val merge4      = Blake2b512Random.merge(Seq(merge3.splitByte(2), delete1Rand))
     val lookup3Rand = merge4.splitByte(0)
     lookup3Rand.next(); lookup3Rand.next();
-    val merge5 = Blake2b512Random.merge(Seq(merge4.splitByte(1), lookup3Rand))
+    val merge5      = Blake2b512Random.merge(Seq(merge4.splitByte(1), lookup3Rand))
     val result3Rand = merge5.splitByte(0)
     val lookup4Rand = merge5.splitByte(1)
     lookup4Rand.next(); lookup4Rand.next();
-    val merge6 = Blake2b512Random.merge(Seq(merge5.splitByte(2), lookup4Rand))
+    val merge6      = Blake2b512Random.merge(Seq(merge5.splitByte(2), lookup4Rand))
     val result4Rand = merge6.splitByte(0)
     val delete2Rand = merge6.splitByte(1)
     // Once for root, and twice for a single iteration through the tree
     delete2Rand.next(); delete2Rand.next(); delete2Rand.next()
-    val merge7 = Blake2b512Random.merge(Seq(merge6.splitByte(2), delete2Rand))
+    val merge7      = Blake2b512Random.merge(Seq(merge6.splitByte(2), delete2Rand))
     val lookup5Rand = merge7.splitByte(0)
     // The last delete should have merged into the root, so it should only take
     // 1 new name.
     lookup5Rand.next();
-    val merge8 = Blake2b512Random.merge(Seq(merge7.splitByte(1), lookup5Rand))
+    val merge8      = Blake2b512Random.merge(Seq(merge7.splitByte(1), lookup5Rand))
     val result5Rand = merge8.splitByte(0)
     val result6Rand = merge8.splitByte(1)
     // This is the last delete. It should take only 1 lookup, because of the
@@ -460,88 +480,89 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
       List(Channel(Quote(GString(s))))
 
     result.get(resultChanList("result0")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result0"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(8))), result0Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result0"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(8))), result0Rand),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result1")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result1"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(9))), result1Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result1"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(9))), result1Rand),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result2")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result2"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(10))), result2Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result2"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(10))), result2Rand),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result3")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result3"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(8))), result3Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result3"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(8))), result3Rand),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result4")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result4"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(9))), result4Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result4"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(9))), result4Rand),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result5")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result5"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(8))), result5Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result5"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(8))), result5Rand),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result6")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result6"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(8))), result6Rand),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result6"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(8))), result6Rand),
+                            false)),
+          List()
+        )))
     result.get(List[Channel](Quote(Registry.registryRoot))) should be(
       Some(Row(
-        List(
-          Datum.create(Channel(Quote(Registry.registryRoot)),
-                       ListChannelWithRandom(Seq(Quote(EMapBody(ParMap(SortedParMap.empty)))), rootRand),
-                       false)),
+        List(Datum.create(Channel(Quote(Registry.registryRoot)),
+                          ListChannelWithRandom(Seq(Quote(EMapBody(ParMap(SortedParMap.empty)))),
+                                                rootRand),
+                          false)),
         List()
       )))
   }
 
   "Public lookup" should "decode and then call lookup" in {
-    val lookupString = """
+    val lookupString =
+      """
       new r(`rho:registry:lookup`) in {
         r!(`rho:id:bnm61w3958nhr5u6wx9yx6c4js77hcxmftc9o1yo4y9yxdu7g8bnq3`, "result0") |
         r!(`rho:id:bnmzm3i5h5hj8qyoh3ubmbu57zuqn56xrk175bw5sf6kook9bq8ny3`, "result1")
       }"""
-    val lookupPar: Par = Interpreter.buildNormalizedTerm(new StringReader(lookupString)).value
+    val lookupPar: Par                  = Interpreter.buildNormalizedTerm(new StringReader(lookupString)).value
     val completePar                     = lookupPar.addSends(rootSend, branchSend)
     implicit val rand: Blake2b512Random = baseRand.splitByte(4)
-    val newRand = rand.splitByte(2)
+    val newRand                         = rand.splitByte(2)
     val randResult0                     = newRand.splitByte(0)
     randResult0.next; randResult0.next
     val randResult1 = newRand.splitByte(1)
     randResult1.next; randResult1.next
 
     val result = withRegistryAndTestSpace { (reducer, space) =>
-      implicit val env    = Env[Par]()
+      implicit val env = Env[Par]()
       val resultTask = for {
         _ <- reducer.eval(completePar)
       } yield space.store.toMap
@@ -552,25 +573,25 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
       List(Channel(Quote(GString(s))))
 
     result.get(resultChanList("result0")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result0"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(8))), randResult0),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result0"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(8))), randResult0),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result1")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result1"))),
-                       ListChannelWithRandom(Seq(Quote(GInt(9))), randResult1),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result1"))),
+                            ListChannelWithRandom(Seq(Quote(GInt(9))), randResult1),
+                            false)),
+          List()
+        )))
   }
 
   "Random Registry" should "use the random generator and insert" in {
-    val registerString = """
+    val registerString                  = """
       new rr(`rho:registry:insertRandom`), rl(`rho:registry:lookup`), x, y in {
         rr!(bundle+{*x}, *y) |
         for(@{uri /\ Uri} <- y) {
@@ -578,11 +599,11 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
           rl!(uri, "result1")
         }
       }"""
-    val registerPar: Par = Interpreter.buildNormalizedTerm(new StringReader(registerString)).value
+    val registerPar: Par                = Interpreter.buildNormalizedTerm(new StringReader(registerString)).value
     val completePar                     = registerPar.addSends(rootSend, branchSend)
     implicit val rand: Blake2b512Random = baseRand.splitByte(5)
-    val newRand = rand.splitByte(2)
-    val registeredName = newRand.next();
+    val newRand                         = rand.splitByte(2)
+    val registeredName                  = newRand.next();
     newRand.next()
     val registerRand = newRand.splitByte(0)
     // Once for Uri and twice for temporary channels to handle the insert.
@@ -591,14 +612,14 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     val insertRand = registerRand
     // Goes directly into root
     insertRand.next();
-    val merge0Rand = Blake2b512Random.merge(Seq(newRand.splitByte(1), insertRand))
+    val merge0Rand  = Blake2b512Random.merge(Seq(newRand.splitByte(1), insertRand))
     val randResult0 = merge0Rand.splitByte(0)
-    val lookupRand = merge0Rand.splitByte(1)
+    val lookupRand  = merge0Rand.splitByte(1)
     lookupRand.next();
     val randResult1 = lookupRand
 
     val result = withRegistryAndTestSpace { (reducer, space) =>
-      implicit val env    = Env[Par]()
+      implicit val env = Env[Par]()
       val resultTask = for {
         _ <- reducer.eval(completePar)
       } yield space.store.toMap
@@ -608,28 +629,26 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     def resultChanList(s: String) =
       List(Channel(Quote(GString(s))))
 
-    val expectedBundle: Par = Bundle(GPrivate(
-      ByteString.copyFrom(registeredName)),
-      writeFlag = true,
-      readFlag = false)
+    val expectedBundle: Par =
+      Bundle(GPrivate(ByteString.copyFrom(registeredName)), writeFlag = true, readFlag = false)
 
     val expectedUri = Registry.buildURI(uriBytes)
 
     result.get(resultChanList("result0")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result0"))),
-                       ListChannelWithRandom(Seq(Quote(GUri(expectedUri))), randResult0),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result0"))),
+                            ListChannelWithRandom(Seq(Quote(GUri(expectedUri))), randResult0),
+                            false)),
+          List()
+        )))
     result.get(resultChanList("result1")) should be(
-      Some(Row(
-        List(
-          Datum.create(Channel(Quote(GString("result1"))),
-                       ListChannelWithRandom(Seq(Quote(expectedBundle)), randResult1),
-                       false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(Datum.create(Channel(Quote(GString("result1"))),
+                            ListChannelWithRandom(Seq(Quote(expectedBundle)), randResult1),
+                            false)),
+          List()
+        )))
   }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingAlgSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingAlgSpec.scala
@@ -57,7 +57,7 @@ class CostAccountingAlgSpec extends FlatSpec with TripleEqualsSupport {
   }
 
   it should "fail when tries to charge on the cost account that is already negative" in { alg =>
-    val cost = Cost(1)
+    val cost            = Cost(1)
     val negativeAccount = CostAccount(-100)
     val test = for {
       _ <- alg.set(negativeAccount)
@@ -69,8 +69,7 @@ class CostAccountingAlgSpec extends FlatSpec with TripleEqualsSupport {
     assert(res === Left(OutOfPhlogistonsError))
   }
 
-  override protected def withFixture(
-      test: OneArgTest): Outcome = {
+  override protected def withFixture(test: OneArgTest): Outcome = {
     val alg = CostAccountingAlg.unsafe[Task](defaultCost)
     test(alg)
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingAlgSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingAlgSpec.scala
@@ -1,0 +1,78 @@
+package coop.rchain.rholang.interpreter.accounting
+import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import org.scalactic.TripleEqualsSupport
+import org.scalatest.Outcome
+import org.scalatest.fixture.FlatSpec
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class CostAccountingAlgSpec extends FlatSpec with TripleEqualsSupport {
+
+  behavior of "CostAccountingAlg"
+
+  val defaultCost = CostAccount(3, Cost(33))
+
+  "set" should "set the cost account" in { alg =>
+    val newState = CostAccount(10, Cost(100L))
+    val test = for {
+      _ <- alg.set(newState)
+      n <- alg.get()
+      _ = assert(n == newState)
+    } yield ()
+
+    Await.ready(test.runAsync, 3.seconds)
+  }
+
+  "get" should "return current cost account" in { alg =>
+    val test = for {
+      s <- alg.get()
+      _ = assert(s == defaultCost)
+    } yield ()
+  }
+
+  "charge" should "modify underlying cost account" in { alg =>
+    val c = Cost(13)
+    val test = for {
+      _ <- alg.charge(c)
+      s <- alg.get()
+      _ = assert(defaultCost.charge(c) == s)
+    } yield ()
+  }
+
+  it should "fail when cost account goes below zero" in { alg =>
+    // this doesn't make sense for now but because we still
+    // add up costs rather than charge we have to do it this way
+    // TODO: Fix once CostAccountingAlg starts subtracting
+    val negativeCost = Cost(-100)
+    val test = for {
+      _ <- alg.charge(negativeCost)
+      s <- alg.get()
+    } yield s
+
+    val res = Await.result(test.attempt.runAsync, 1.second)
+    assert(res === Left(OutOfPhlogistonsError))
+  }
+
+  it should "fail when tries to charge on the cost account that is already negative" in { alg =>
+    val cost = Cost(1)
+    val negativeAccount = CostAccount(-100)
+    val test = for {
+      _ <- alg.set(negativeAccount)
+      _ <- alg.charge(cost)
+      s <- alg.get()
+    } yield s
+
+    val res = Await.result(test.attempt.runAsync, 1.second)
+    assert(res === Left(OutOfPhlogistonsError))
+  }
+
+  override protected def withFixture(
+      test: OneArgTest): Outcome = {
+    val alg = CostAccountingAlg.unsafe[Task](defaultCost)
+    test(alg)
+  }
+  override type FixtureParam = CostAccountingAlg[Task]
+}

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -13,6 +13,7 @@ import coop.rchain.rholang.interpreter.PrettyPrinter
 import coop.rchain.rholang.interpreter.matcher.OptionalFreeMapWithCost.toOptionalFreeMapWithCostOps
 import monix.eval.Coeval
 import org.scalatest._
+import coop.rchain.rholang.interpreter.accounting.CostAccount
 import org.scalatest.concurrent.TimeLimits
 import scalapb.GeneratedMessage
 
@@ -35,7 +36,7 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
     assertSorted(pattern, "pattern")
     expectedCaptures.foreach(
       _.values.foreach((v: Par) => assertSorted(v, "expected captured term")))
-    val result: Option[FreeMap] = spatialMatch(target, pattern).runWithCost._2.map(_._1)
+    val result: Option[FreeMap] = spatialMatch(target, pattern).runWithCost(CostAccount(0))._2.map(_._1)
     assert(prettyCaptures(result) == prettyCaptures(expectedCaptures))
     assert(result == expectedCaptures)
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -36,7 +36,8 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
     assertSorted(pattern, "pattern")
     expectedCaptures.foreach(
       _.values.foreach((v: Par) => assertSorted(v, "expected captured term")))
-    val result: Option[FreeMap] = spatialMatch(target, pattern).runWithCost(CostAccount(0))._2.map(_._1)
+    val result: Option[FreeMap] =
+      spatialMatch(target, pattern).runWithCost(CostAccount(0))._2.map(_._1)
     assert(prettyCaptures(result) == prettyCaptures(expectedCaptures))
     assert(result == expectedCaptures)
   }
@@ -60,9 +61,8 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
   }
 
   private def prettyCaptures[T <: GeneratedMessage, P <: GeneratedMessage](
-      expectedCaptures: Option[FreeMap]): Option[Map[Int, String]] = {
+      expectedCaptures: Option[FreeMap]): Option[Map[Int, String]] =
     expectedCaptures.map(_.map(c => (c._1, printer.buildString(c._2))))
-  }
 
   private def assertSorted[T <: GeneratedMessage](term: T, termName: String)(
       implicit ts: Sortable[T]): Assertion = {
@@ -104,13 +104,14 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
     val pattern: Par = EList(List(EVar(FreeVar(0)).withConnectiveUsed(true), GInt(9)), BitSet())
       .withConnectiveUsed(true)
       .prepend(EList(List(GInt(7), EVar(FreeVar(1)).withConnectiveUsed(true)), BitSet())
-        .withConnectiveUsed(true), depth = 1)
+                 .withConnectiveUsed(true),
+               depth = 1)
     assertSpatialMatch(target, pattern, Some(Map[Int, Par](0 -> GInt(7), 1 -> GInt(8))))
   }
 
   "Matching huge list of targets with no patterns and a reminder" should "better be quick" in {
     //This is a very common case in rspace that can be handled in linear time, yet was quadratic for a short while
-    val target: Par = Par(exprs = Seq.fill(1000)(GInt(1): Expr))
+    val target: Par  = Par(exprs = Seq.fill(1000)(GInt(1): Expr))
     val pattern: Par = EVar(FreeVar(0))
 
     import org.scalatest.time.SpanSugar._
@@ -151,12 +152,14 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
   "Matching extras with free variable" should "work" in {
     val target: Par  = GInt(9).prepend(GInt(8), depth = 0).prepend(GInt(7), depth = 0)
     val pattern: Par = EVar(FreeVar(0)).prepend(GInt(8), depth = 1)
-    assertSpatialMatch(target, pattern, Some(Map[Int, Par](0 -> GInt(9).prepend(GInt(7), depth = 0))))
+    assertSpatialMatch(target,
+                       pattern,
+                       Some(Map[Int, Par](0 -> GInt(9).prepend(GInt(7), depth = 0))))
   }
 
   "Matching a singleton list" should "work" in {
-    val target: Expr  = EList(Seq(GInt(1)))
-    val pattern: Expr = EList(Seq(EVar(FreeVar(0))), connectiveUsed = true)
+    val target: Expr   = EList(Seq(GInt(1)))
+    val pattern: Expr  = EList(Seq(EVar(FreeVar(0))), connectiveUsed = true)
     val expectedResult = Some(Map[Int, Par](0 -> GInt(1)))
     assertSpatialMatch(target, pattern, expectedResult)
     assertSpatialMatch(target: Par, pattern: Par, expectedResult)
@@ -166,8 +169,9 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
     //     Matching:  free0 | free1
     //           to:  1 | 1
     // should yield:  Some(Map(0 -> 1 | 1))
-    val target: Par    = GInt(1).prepend(GInt(1), depth = 0)
-    val pattern: Par   = EVar(FreeVar(1)).prepend(EVar(FreeVar(0)), depth = 0).withConnectiveUsed(true)
+    val target: Par = GInt(1).prepend(GInt(1), depth = 0)
+    val pattern: Par =
+      EVar(FreeVar(1)).prepend(EVar(FreeVar(0)), depth = 0).withConnectiveUsed(true)
     val expectedResult = Some(Map[Int, Par](0 -> target))
     assertSpatialMatch(target, pattern, expectedResult)
   }
@@ -268,10 +272,14 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
     assertSpatialMatch(target, pattern, Some(Map.empty[Int, Par]))
   }
   "Matching extras with wildcard and free variable" should "capture in the free variable" in {
-    val target: Par  = GInt(9).prepend(GInt(8), depth = 0).prepend(GInt(7), depth = 0)
+    val target: Par = GInt(9).prepend(GInt(8), depth = 0).prepend(GInt(7), depth = 0)
     val pattern: Par =
-      EVar(Wildcard(Var.WildcardMsg())).prepend(EVar(FreeVar(0)), depth = 1).prepend(GInt(8), depth = 1)
-    assertSpatialMatch(target, pattern, Some(Map[Int, Par](0 -> GInt(9).prepend(GInt(7), depth = 0))))
+      EVar(Wildcard(Var.WildcardMsg()))
+        .prepend(EVar(FreeVar(0)), depth = 1)
+        .prepend(GInt(8), depth = 1)
+    assertSpatialMatch(target,
+                       pattern,
+                       Some(Map[Int, Par](0 -> GInt(9).prepend(GInt(7), depth = 0))))
   }
   "Matching send with free variable in channel and variable position" should "capture both values" in {
     val sendTarget: Par =
@@ -279,7 +287,8 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
     val pattern: Par =
       Send(ChanVar(FreeVar(0)), List(GInt(7), EVar(FreeVar(1))), false, BitSet(), true)
         .withConnectiveUsed(true)
-    val expectedResult = Some(Map[Int, Par](0 -> GPrivateBuilder("zero"), 1 -> GPrivateBuilder("one")))
+    val expectedResult =
+      Some(Map[Int, Par](0 -> GPrivateBuilder("zero"), 1 -> GPrivateBuilder("one")))
     assertSpatialMatch(sendTarget, pattern, expectedResult)
     val targetPar: Par  = sendTarget
     val patternPar: Par = pattern
@@ -308,9 +317,11 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
     )
     val expectedResult =
       Some(
-        Map[Int, Par](
-          0 -> GInt(8),
-          1 -> Send(Quote(GPrivateBuilder("unforgeable")), List(GInt(9), GInt(10)), false, BitSet())))
+        Map[Int, Par](0 -> GInt(8),
+                      1 -> Send(Quote(GPrivateBuilder("unforgeable")),
+                                List(GInt(9), GInt(10)),
+                                false,
+                                BitSet())))
     assertSpatialMatch(target, pattern, expectedResult)
     val targetPar: Par  = target
     val patternPar: Par = pattern
@@ -402,8 +413,9 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
   it should "work with free variables and wildcards" in {
     val target: Expr = ParSet(Seq(GInt(1), GInt(2), GInt(3), GInt(4), GInt(5)))
     val pattern: Expr =
-      ParSet(Seq(GInt(2), GInt(5), EVar(FreeVar(0)), EVar(FreeVar(1)), EVar(Wildcard(WildcardMsg()))),
-             connectiveUsed = true)
+      ParSet(
+        Seq(GInt(2), GInt(5), EVar(FreeVar(0)), EVar(FreeVar(1)), EVar(Wildcard(WildcardMsg()))),
+        connectiveUsed = true)
     //the captures and their order are somewhat arbitrary and could potentially by changed
     val expectedResult = Some(Map[Int, Par](0 -> GInt(4), 1 -> GInt(3)))
     assertSpatialMatch(target, pattern, expectedResult)
@@ -413,13 +425,14 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
     assertSpatialMatch(targetPar, patternPar, expectedResult)
 
     val nonMatchingPattern: Expr =
-      ParSet(Seq(GInt(2), GInt(5), EVar(FreeVar(0)), EVar(Wildcard(WildcardMsg()))), connectiveUsed = true)
+      ParSet(Seq(GInt(2), GInt(5), EVar(FreeVar(0)), EVar(Wildcard(WildcardMsg()))),
+             connectiveUsed = true)
     assertSpatialMatch(target, nonMatchingPattern, None)
   }
 
   it should "work with wildcard remainders" in {
     val targetElements = Seq[Par](GInt(1), GInt(2), GInt(3), GInt(4), GInt(5))
-    val target: Expr = ParSet(targetElements)
+    val target: Expr   = ParSet(targetElements)
     val pattern: Expr =
       ParSet(Seq(GInt(1), GInt(4)), connectiveUsed = true, remainder = Wildcard(WildcardMsg()))
     val expectedResult = Some(Map[Int, Par]())
@@ -438,9 +451,11 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
 
   it should "work with var remainders" in {
     val targetElements = Seq[Par](GInt(1), GInt(2), GInt(3), GInt(4), GInt(5))
-    val target: Expr = ParSet(targetElements)
+    val target: Expr   = ParSet(targetElements)
     val pattern: Expr =
-      ParSet(Seq(GInt(1), GInt(4), EVar(FreeVar(0))), connectiveUsed = true, remainder = Var(FreeVar(1)))
+      ParSet(Seq(GInt(1), GInt(4), EVar(FreeVar(0))),
+             connectiveUsed = true,
+             remainder = Var(FreeVar(1)))
     //the captures and their order are somewhat arbitrary and could potentially by changed
     val expectedResult = Some(Map[Int, Par](0 -> GInt(2), 1 -> ParSet(Seq(GInt(3), GInt(5)))))
     assertSpatialMatch(target, pattern, expectedResult)
@@ -469,15 +484,15 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
   }
 
   it should "work with free variables and wildcards" in {
-    val target: Expr = ParMap(
-      Seq[(Par, Par)]((GInt(1), GInt(2)), (GInt(3), GInt(4)), (GInt(5), GInt(6))))
+    val target: Expr =
+      ParMap(Seq[(Par, Par)]((GInt(1), GInt(2)), (GInt(3), GInt(4)), (GInt(5), GInt(6))))
     val pattern: Expr =
       ParMap(
         Seq[(Par, Par)](
           (GInt(1), EVar(FreeVar(1))),
           (GInt(3), GInt(4)),
           (EVar(FreeVar(0)), EVar(Wildcard(WildcardMsg())))
-      ),
+        ),
         connectiveUsed = true,
         locallyFree = BitSet(0, 1),
         remainder = None
@@ -505,7 +520,7 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
 
   it should "work with wildcard remainders" in {
     val targetElements = Seq[(Par, Par)]((GInt(1), GInt(2)), (GInt(3), GInt(4)), (GInt(5), GInt(6)))
-    val target: Expr = ParMap(targetElements)
+    val target: Expr   = ParMap(targetElements)
     val pattern: Expr =
       ParMap(Seq[(Par, Par)]((GInt(3), GInt(4))),
              connectiveUsed = true,
@@ -536,28 +551,24 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
     val target: Expr   = ParMap(targetElements)
     val pattern: Expr =
       ParMap(Seq[(Par, Par)]((EVar(FreeVar(0)), GInt(4))),
-        connectiveUsed = true,
-        locallyFree = BitSet(),
-        remainder = FreeVar(1))
+             connectiveUsed = true,
+             locallyFree = BitSet(),
+             remainder = FreeVar(1))
     val expectedResult = Some(
       Map[Int, Par](0 -> GInt(3),
-        1 -> ParMap(Seq[(Par, Par)]((GInt(1), GInt(2)), (GInt(5), GInt(6))))))
+                    1 -> ParMap(Seq[(Par, Par)]((GInt(1), GInt(2)), (GInt(5), GInt(6))))))
     assertSpatialMatch(target, pattern, expectedResult)
 
     val targetPar: Par  = target
     val patternPar: Par = pattern
     assertSpatialMatch(targetPar, patternPar, expectedResult)
 
-    val allElementsAndRemainder: Expr = ParMap(targetElements,
-      connectiveUsed = true,
-      locallyFree = BitSet(),
-      remainder = FreeVar(0))
+    val allElementsAndRemainder: Expr =
+      ParMap(targetElements, connectiveUsed = true, locallyFree = BitSet(), remainder = FreeVar(0))
     assertSpatialMatch(target, allElementsAndRemainder, Some(Map[Int, Par](0 -> ParMap(Seq.empty))))
 
-    val justRemainder: Expr = ParMap(Seq(),
-      connectiveUsed = true,
-      locallyFree = BitSet(),
-      remainder = FreeVar(0))
+    val justRemainder: Expr =
+      ParMap(Seq(), connectiveUsed = true, locallyFree = BitSet(), remainder = FreeVar(0))
     assertSpatialMatch(target, justRemainder, Some(Map[Int, Par](0 -> ParMap(targetElements))))
   }
 
@@ -725,6 +736,7 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
   }
 
   "Matching a target with var ref and a pattern with a var ref" should "ignore locallyFree" in {
+    // format: off
     val target: Par = New(
       bindCount = 1,
       p = Par(
@@ -751,6 +763,7 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
           body = Par(),
           persistent = false,
           bindCount = 0))))
+    // format: on
     assertSpatialMatch(target, pattern, Some(Map.empty[Int, Par]))
   }
 
@@ -786,8 +799,8 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
   }
 
   "Matching Bool" should "work" in {
-    val successTarget: Par = GBool(false)
-    val failTarget: Par = GString("Fail")
+    val successTarget: Par  = GBool(false)
+    val failTarget: Par     = GString("Fail")
     val pattern: Connective = Connective(ConnBool(true))
 
     assertSpatialMatch(successTarget, pattern, Some(Map.empty))
@@ -795,8 +808,8 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
   }
 
   "Matching Int" should "work" in {
-    val successTarget: Par = GInt(7)
-    val failTarget: Par = GString("Fail")
+    val successTarget: Par  = GInt(7)
+    val failTarget: Par     = GString("Fail")
     val pattern: Connective = Connective(ConnInt(true))
 
     assertSpatialMatch(successTarget, pattern, Some(Map.empty))
@@ -804,8 +817,8 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
   }
 
   "Matching String" should "work" in {
-    val successTarget: Par = GString("Match me!")
-    val failTarget: Par = GInt(42)
+    val successTarget: Par  = GString("Match me!")
+    val failTarget: Par     = GInt(42)
     val pattern: Connective = Connective(ConnString(true))
 
     assertSpatialMatch(successTarget, pattern, Some(Map.empty))
@@ -813,8 +826,8 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
   }
 
   "Matching Uri" should "work" in {
-    val successTarget: Par = GUri("rho:io:stdout")
-    val failTarget: Par = GString("Fail")
+    val successTarget: Par  = GUri("rho:io:stdout")
+    val failTarget: Par     = GString("Fail")
     val pattern: Connective = Connective(ConnUri(true))
 
     assertSpatialMatch(successTarget, pattern, Some(Map.empty))
@@ -822,8 +835,8 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits {
   }
 
   "Matching ByteArray" should "work" in {
-    val successTarget: Par = GByteArray(ByteString.copyFrom(Array[Byte](74, 75)))
-    val failTarget: Par = GString("Fail")
+    val successTarget: Par  = GByteArray(ByteString.copyFrom(Array[Byte](74, 75)))
+    val failTarget: Par     = GString("Fail")
     val pattern: Connective = Connective(ConnByteArray(true))
 
     assertSpatialMatch(successTarget, pattern, Some(Map.empty))


### PR DESCRIPTION
## Overview
This PR contains a subset of the changes I've made in the course or RHOL-11. Specifically this PR:
+ explicitly pass initial phlos when running spatial match  - this is preliminary work for deducting the phlos from the available and short-circuiting the matcher
+ simplifies API of the `CostAccountingAlg` - turns out it can be much simpler and still provide necessary functionality
+ adds a test for `CostAccountingAlg`
+ replaces `modifyCost(f: CostAccount => CostAccount)` method with `charge(c: Cost)`

### Does this PR relate to an RChain JIRA issue? 
If applicable, add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ ] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
